### PR TITLE
export default variables as interface types

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -59,12 +59,12 @@ var LevelColors = map[Level]Color{
 }
 
 var (
-	DefaultLogger    = NewLogger(procName())
-	DefaultLevel     = INFO
-	DefaultHandler   = StderrHandler
-	DefaultFormatter = &defaultFormatter{}
-	StdoutHandler    = NewWriterHandler(os.Stdout)
-	StderrHandler    = NewWriterHandler(os.Stderr)
+	DefaultLogger    Logger    = NewLogger(procName())
+	DefaultLevel     Level     = INFO
+	DefaultHandler   Handler   = StderrHandler
+	DefaultFormatter Formatter = &defaultFormatter{}
+	StdoutHandler              = NewWriterHandler(os.Stdout)
+	StderrHandler              = NewWriterHandler(os.Stderr)
 )
 
 func init() {


### PR DESCRIPTION
Needed to override the default handler when doing https://github.com/koding/kite/issues/6

Normally this should not break any existing users of this code.
