### PR TITLE
Implement inherited based logger from a given context/prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Features
 * Customizable logging handlers
 * Customizable formatters
 * Log to multiple backends concurrently
+* Context based (inherited) loggers
 
 
 Example Usage

--- a/context.go
+++ b/context.go
@@ -1,0 +1,64 @@
+package logging
+
+type context struct {
+	prefix string
+	logger
+}
+
+// Fatal is equivalent to Critical() followed by a call to os.Exit(1).
+func (c *context) Fatal(format string, args ...interface{}) {
+	c.logger.Fatal(c.prefixFormat()+format, args...)
+}
+
+// Panic is equivalent to Critical() followed by a call to panic().
+func (c *context) Panic(format string, args ...interface{}) {
+	c.logger.Panic(c.prefixFormat()+format, args...)
+}
+
+// Critical sends a critical level log message to the handler. Arguments are
+// handled in the manner of fmt.Printf.
+func (c *context) Critical(format string, args ...interface{}) {
+	c.logger.Critical(c.prefixFormat()+format, args...)
+}
+
+// Error sends a error level log message to the handler. Arguments are handled
+// in the manner of fmt.Printf.
+func (c *context) Error(format string, args ...interface{}) {
+	c.logger.Error(c.prefixFormat()+format, args...)
+}
+
+// Warning sends a warning level log message to the handler. Arguments are
+// handled in the manner of fmt.Printf.
+func (c *context) Warning(format string, args ...interface{}) {
+	c.logger.Warning(c.prefixFormat()+format, args...)
+}
+
+// Notice sends a notice level log message to the handler. Arguments are
+// handled in the manner of fmt.Printf.
+func (c *context) Notice(format string, args ...interface{}) {
+	c.logger.Notice(c.prefixFormat()+format, args...)
+}
+
+// Info sends a info level log message to the handler. Arguments are handled in
+// the manner of fmt.Printf.
+func (c *context) Info(format string, args ...interface{}) {
+	c.logger.Info(c.prefixFormat()+format, args...)
+}
+
+// Debug sends a debug level log message to the handler. Arguments are handled
+// in the manner of fmt.Printf.
+func (c *context) Debug(format string, args ...interface{}) {
+	c.logger.Debug(c.prefixFormat()+format, args...)
+}
+
+func (c *context) New(prefix string) Logger {
+	d := &context{
+		prefix: c.prefix + "[" + prefix + "]",
+	}
+	d.logger = c.logger
+	return d
+}
+
+func (c *context) prefixFormat() string {
+	return c.prefix + " "
+}

--- a/logging.go
+++ b/logging.go
@@ -82,6 +82,9 @@ type Logger interface {
 	// the Logger. Default value is zero.
 	SetCallDepth(int)
 
+	// New creates a new inerhited context logger with the given prefix.
+	New(prefix string) Logger
+
 	// Fatal is equivalent to l.Critical followed by a call to os.Exit(1).
 	Fatal(format string, args ...interface{})
 
@@ -172,6 +175,15 @@ func NewLogger(name string) Logger {
 		Level:   DefaultLevel,
 		Handler: DefaultHandler,
 	}
+}
+
+// New creates a new inerhited logger with the given prefix
+func (l *logger) New(prefix string) Logger {
+	c := &context{
+		prefix: "[" + prefix + "]",
+	}
+	c.logger = *l
+	return c
 }
 
 func (l *logger) SetLevel(level Level) {


### PR DESCRIPTION
This is needed so we can create context based loggers. Especially useful if we want to filter based on multiple users/clients etc.. An example API usage would be:

```go
package main

import "github.com/koding/logging"

func main() {
	log := logging.NewLogger("kite")
	log.Info("This is an ordinary message")
	log.Warning("Warning!")

	foo := log.New("foo")
	bar := log.New("bar")

	foo.Info("request has been made")
	bar.Info("resize is initiated")

	resize := foo.New("resize")
	resize.Info("checking size requirements")
	resize.Error("not allowed: %s", "permission denied")

	start := bar.New("start")
	start.Critical("OMG!")
}
```

![image](https://cloud.githubusercontent.com/assets/438920/6463117/eeda3c04-c1b7-11e4-97ef-f78dd7895830.png)

Totally backwards compatible, in terms of API methods and performance (context formatter is only substituted if someone calls the `logger.New()`)