### PR TITLE
Support multiple contex variables 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: go
+go:
+  - 1.3
+  - 1.4.2
+  - tip

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ logging
 
 Simple logging package in Go.
 
-[![GoDoc](https://godoc.org/github.com/koding/logging?status.png)](https://godoc.org/github.com/koding/logging)
+[![GoDoc](https://godoc.org/github.com/koding/logging?status.svg)](https://godoc.org/github.com/koding/logging)
+[![Build Status](https://travis-ci.org/koding/logging.svg)](https://travis-ci.org/koding/logging)
 
 
 Install

--- a/context.go
+++ b/context.go
@@ -1,5 +1,7 @@
 package logging
 
+import "fmt"
+
 type context struct {
 	prefix string
 	logger
@@ -51,14 +53,34 @@ func (c *context) Debug(format string, args ...interface{}) {
 	c.logger.Debug(c.prefixFormat()+format, args...)
 }
 
-func (c *context) New(prefix string) Logger {
-	d := &context{
-		prefix: c.prefix + "[" + prefix + "]",
-	}
-	d.logger = c.logger
-	return d
+// New creates a new Logger from current context
+func (c *context) New(prefixes ...interface{}) Logger {
+	return newContext(c.logger, c.prefix, prefixes...)
 }
 
 func (c *context) prefixFormat() string {
 	return c.prefix + " "
+}
+
+func newContext(logger logger, initial string, prefixes ...interface{}) *context {
+	resultPrefix := "" // resultPrefix holds prefix after initialization
+	connector := ""    // connector holds the connector string
+
+	for _, prefix := range prefixes {
+		resultPrefix += fmt.Sprintf("%s%+v", connector, prefix)
+		switch connector {
+		case "=": // if previous is `=` replace with ][
+			connector = "]["
+		case "][": // if previous is `][` replace with =
+			connector = "="
+		default:
+			connector = "=" // if its first iteration, assing =
+		}
+	}
+
+	return &context{
+		prefix: initial + "[" + resultPrefix + "]",
+		logger: logger,
+	}
+
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,42 @@
+package logging
+
+import "testing"
+
+func TestContext(t *testing.T) {
+	var tds = []struct {
+		expected string
+		context  []interface{}
+	}{
+		{
+			expected: "[prefix]",
+			context:  []interface{}{"prefix"},
+		},
+		{
+			expected: "[isEnabled=true][count=1233123123123][name=koding][standalone]",
+			context: []interface{}{
+				"isEnabled", true,
+				"count", 1233123123123,
+				"name", "koding",
+				"standalone",
+			},
+		},
+		{
+			expected: "[isEnabled=true][count=1233123123123][name=koding][ratio=3.42323]",
+			context: []interface{}{
+				"isEnabled", true,
+				"count", 1233123123123,
+				"name", "koding",
+				"ratio", 3.42323,
+			},
+		},
+	}
+
+	l := NewLogger("test")
+
+	for _, td := range tds {
+		contextedLogger := l.New(td.context...)
+		if contextedLogger.(*context).prefix != td.expected {
+			t.Fatalf("Prefix expected as %s, got: %s", td.expected, contextedLogger.(*context).prefix)
+		}
+	}
+}

--- a/logging.go
+++ b/logging.go
@@ -13,7 +13,10 @@ import (
 )
 
 type (
+	// Color represents log level colors
 	Color int
+
+	// Level represent severity of logs
 	Level int
 )
 
@@ -39,6 +42,7 @@ const (
 	DEBUG
 )
 
+// LevelNames provides mapping for log levels
 var LevelNames = map[Level]string{
 	CRITICAL: "CRITICAL",
 	ERROR:    "ERROR",
@@ -48,6 +52,7 @@ var LevelNames = map[Level]string{
 	DEBUG:    "DEBUG",
 }
 
+// LevelColors provides mapping for log colors
 var LevelColors = map[Level]Color{
 	CRITICAL: MAGENTA,
 	ERROR:    RED,
@@ -58,12 +63,23 @@ var LevelColors = map[Level]Color{
 }
 
 var (
-	DefaultLogger    Logger    = NewLogger(procName())
-	DefaultLevel     Level     = INFO
-	DefaultHandler   Handler   = StderrHandler
+	// DefaultLogger holds default logger
+	DefaultLogger Logger = NewLogger(procName())
+
+	// DefaultLevel holds default value for loggers
+	DefaultLevel Level = INFO
+
+	// DefaultHandler holds default handler for loggers
+	DefaultHandler Handler = StderrHandler
+
+	// DefaultFormatter holds default formatter for loggers
 	DefaultFormatter Formatter = &defaultFormatter{}
-	StdoutHandler              = NewWriterHandler(os.Stdout)
-	StderrHandler              = NewWriterHandler(os.Stderr)
+
+	// StdoutHandler holds a handler with outputting to stdout
+	StdoutHandler = NewWriterHandler(os.Stdout)
+
+	// StderrHandler holds a handler with outputting to stderr
+	StderrHandler = NewWriterHandler(os.Stderr)
 )
 
 // Logger is the interface for outputing log messages in different levels.
@@ -83,7 +99,7 @@ type Logger interface {
 	SetCallDepth(int)
 
 	// New creates a new inerhited context logger with the given prefix.
-	New(prefix string) Logger
+	New(prefixes ...interface{}) Logger
 
 	// Fatal is equivalent to l.Critical followed by a call to os.Exit(1).
 	Fatal(format string, args ...interface{})
@@ -177,13 +193,9 @@ func NewLogger(name string) Logger {
 	}
 }
 
-// New creates a new inerhited logger with the given prefix
-func (l *logger) New(prefix string) Logger {
-	c := &context{
-		prefix: "[" + prefix + "]",
-	}
-	c.logger = *l
-	return c
+// New creates a new inerhited logger with the given prefixes
+func (l *logger) New(prefixes ...interface{}) Logger {
+	return newContext(*l, "", prefixes...)
 }
 
 func (l *logger) SetLevel(level Level) {
@@ -334,11 +346,13 @@ func Debug(format string, args ...interface{}) {
 //             //
 /////////////////
 
+// BaseHandler provides basic functionality for handler
 type BaseHandler struct {
 	Level     Level
 	Formatter Formatter
 }
 
+// NewBaseHandler creates a newBaseHandler with default values
 func NewBaseHandler() *BaseHandler {
 	return &BaseHandler{
 		Level:     DefaultLevel,
@@ -346,14 +360,17 @@ func NewBaseHandler() *BaseHandler {
 	}
 }
 
+// SetLevel sets logging level for handler
 func (h *BaseHandler) SetLevel(l Level) {
 	h.Level = l
 }
 
+// SetFormatter sets logging formatter for handler
 func (h *BaseHandler) SetFormatter(f Formatter) {
 	h.Formatter = f
 }
 
+// FilterAndFormat filters any record according to loggging level
 func (h *BaseHandler) FilterAndFormat(rec *Record) string {
 	if h.Level >= rec.Level {
 		return h.Formatter.Format(rec)
@@ -374,6 +391,7 @@ type WriterHandler struct {
 	Colorize bool
 }
 
+// NewWriterHandler creates a new writer handler with given io.Writer
 func NewWriterHandler(w io.Writer) *WriterHandler {
 	return &WriterHandler{
 		BaseHandler: NewBaseHandler(),
@@ -381,6 +399,7 @@ func NewWriterHandler(w io.Writer) *WriterHandler {
 	}
 }
 
+// Handle writes any given Record to the Writer.
 func (b *WriterHandler) Handle(rec *Record) {
 	message := b.BaseHandler.FilterAndFormat(rec)
 	if message == "" {
@@ -395,6 +414,7 @@ func (b *WriterHandler) Handle(rec *Record) {
 	}
 }
 
+// Close closes WriterHandler
 func (b *WriterHandler) Close() {}
 
 //////////////////
@@ -408,22 +428,26 @@ type MultiHandler struct {
 	handlers []Handler
 }
 
+// NewMultiHandler creates a new handler with given handlers
 func NewMultiHandler(handlers ...Handler) *MultiHandler {
 	return &MultiHandler{handlers: handlers}
 }
 
+// SetFormatter sets formatter for all handlers
 func (b *MultiHandler) SetFormatter(f Formatter) {
 	for _, h := range b.handlers {
 		h.SetFormatter(f)
 	}
 }
 
+// SetLevel sets level for all handlers
 func (b *MultiHandler) SetLevel(l Level) {
 	for _, h := range b.handlers {
 		h.SetLevel(l)
 	}
 }
 
+// Handle handles given record with all handlers concurrently
 func (b *MultiHandler) Handle(rec *Record) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(b.handlers))
@@ -436,6 +460,7 @@ func (b *MultiHandler) Handle(rec *Record) {
 	wg.Wait()
 }
 
+// Close closes all handlers concurrently
 func (b *MultiHandler) Close() {
 	wg := sync.WaitGroup{}
 	wg.Add(len(b.handlers))

--- a/logging_example_test.go
+++ b/logging_example_test.go
@@ -1,0 +1,45 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+)
+
+type exampleFormatter struct{}
+
+func (f *exampleFormatter) Format(rec *Record) string {
+	return fmt.Sprintf("%-8s [%-4s] %s",
+		LevelNames[rec.Level],
+		rec.LoggerName,
+		fmt.Sprintf(rec.Format, rec.Args...),
+	)
+}
+
+func ExampleContexted() {
+	// Custom logger with new std out handler
+	l := NewLogger("test")
+	l.SetLevel(DEBUG)
+
+	// create handler
+	logHandler := NewWriterHandler(os.Stdout)
+	logHandler.SetLevel(DEBUG)
+	logHandler.Formatter = &exampleFormatter{}
+	// set handler
+	l.SetHandler(logHandler)
+
+	// Custom logger with inherited handler
+	ctx1 := l.New("example")
+	ctx1.Debug("Debug")
+
+	// derive new one from previous contexted
+	ctx2 := ctx1.New("debug", true, "level", 2, "example")
+	ctx2.Debug("Debug")
+
+	// create new context inline
+	ctx1.New("standalone").Debug("Debug")
+
+	// Output:
+	//DEBUG    [test] [example] Debug
+	//DEBUG    [test] [example][debug=true][level=2][example] Debug
+	//DEBUG    [test] [example][standalone] Debug
+}


### PR DESCRIPTION
* This PR enables having multiple context variables with key value pairs. 
* Instead of having to use formatting directives, it is easier and more manageable to use context variables while logging. 
* Totally backward compatible API
* Adds travis integration